### PR TITLE
add sorting fields

### DIFF
--- a/src/components/molecules/BlackholeForm/organisms/BlackholeForm/BlackholeForm.tsx
+++ b/src/components/molecules/BlackholeForm/organisms/BlackholeForm/BlackholeForm.tsx
@@ -61,6 +61,7 @@ type TBlackholeFormCreateProps = {
   hiddenPaths?: string[][]
   expandedPaths: string[][]
   persistedPaths: string[][]
+  sortPaths?: string[][]
   prefillValuesSchema?: TJSON
   prefillValueNamespaceOnly?: string
   isNameSpaced?: false | string[]
@@ -87,6 +88,7 @@ export const BlackholeForm: FC<TBlackholeFormCreateProps> = ({
   hiddenPaths,
   expandedPaths,
   persistedPaths,
+  sortPaths,
   prefillValuesSchema,
   prefillValueNamespaceOnly,
   isNameSpaced,
@@ -1184,6 +1186,7 @@ export const BlackholeForm: FC<TBlackholeFormCreateProps> = ({
                       isEdit: !isCreate,
                       expandedControls: { onExpandOpen, onExpandClose, expandedKeys },
                       persistedControls: { onPersistMark, onPersistUnmark, persistedKeys },
+                      sortPaths,
                       urlParams,
                     })}
                   </HiddenPathsProvider>

--- a/src/components/molecules/BlackholeForm/organisms/BlackholeForm/utils.tsx
+++ b/src/components/molecules/BlackholeForm/organisms/BlackholeForm/utils.tsx
@@ -321,6 +321,7 @@ export const getArrayFormItemFromSwagger = ({
   isEdit,
   expandedControls,
   persistedControls,
+  sortPaths,
   urlParams,
   onRemoveByMinus,
 }: {
@@ -354,6 +355,7 @@ export const getArrayFormItemFromSwagger = ({
   isEdit: boolean
   expandedControls: TExpandedControls
   persistedControls: TPersistedControls
+  sortPaths?: string[][]
   urlParams: TUrlParams
   onRemoveByMinus?: () => void
 }) => {
@@ -524,6 +526,7 @@ export const getArrayFormItemFromSwagger = ({
                             isEdit,
                             expandedControls,
                             persistedControls,
+                            sortPaths,
                             urlParams,
                             onRemoveByMinus: () => remove(field.name),
                           })}
@@ -561,6 +564,7 @@ export const getArrayFormItemFromSwagger = ({
                         isEdit,
                         expandedControls,
                         persistedControls,
+                        sortPaths,
                         urlParams,
                         onRemoveByMinus: () => remove(field.name),
                       })}
@@ -605,6 +609,7 @@ export const getObjectFormItemsDraft = ({
   isEdit,
   expandedControls,
   persistedControls,
+  sortPaths,
   urlParams,
 }: {
   properties: {
@@ -639,12 +644,54 @@ export const getObjectFormItemsDraft = ({
   isEdit: boolean
   expandedControls: TExpandedControls
   persistedControls: TPersistedControls
+  sortPaths?: string[][]
   urlParams: TUrlParams
 }) => {
+  // Function to sort properties based on sortPaths
+  const getSortedPropertyKeys = (): (keyof typeof properties)[] => {
+    if (!sortPaths || sortPaths.length === 0) {
+      return Object.keys(properties) as (keyof typeof properties)[]
+    }
+
+    const currentPath = Array.isArray(name) ? name : [name]
+    const currentPathStr = JSON.stringify(currentPath)
+    
+    // Find sort order for current path
+    const currentSortPaths = sortPaths.filter(path => {
+      // For root level (empty array), match paths with single element
+      if (currentPath.length === 0) {
+        return path.length === 1
+      }
+      
+      // For nested levels, match parent path
+      const pathStr = JSON.stringify(path.slice(0, -1)) // Remove last element to match parent path
+      return pathStr === currentPathStr
+    })
+
+    if (currentSortPaths.length === 0) {
+      return Object.keys(properties) as (keyof typeof properties)[]
+    }
+
+    // Create sort order map
+    const sortOrder = new Map<string, number>()
+    currentSortPaths.forEach((path, index) => {
+      // For root level, use the first element as key
+      // For nested levels, use the last element as key
+      const key = currentPath.length === 0 ? path[0] : path[path.length - 1]
+      sortOrder.set(key, index)
+    })
+
+    // Sort properties based on sort order
+    return Object.keys(properties).sort((a, b) => {
+      const aOrder = sortOrder.get(a) ?? Number.MAX_SAFE_INTEGER
+      const bOrder = sortOrder.get(b) ?? Number.MAX_SAFE_INTEGER
+      return aOrder - bOrder
+    }) as (keyof typeof properties)[]
+  }
+
   return (
     <HiddenContainer name={name} key={`${arrKey}-${JSON.stringify(name)}`}>
-      {Object.keys(properties).map((el: keyof typeof properties) => {
-        // if (properties[el].type === 'object' && properties[el]['x-kubernetes-preserve-unknown-fields']) {
+      {getSortedPropertyKeys().map((el: keyof typeof properties) => {
         if (properties[el]['x-kubernetes-preserve-unknown-fields']) {
           // return <Alert key={String(el)} message="x-kubernetes-preserve-unknown-fields" banner />
           const path = Array.isArray(name) ? [...name, String(el)] : [name, String(el)]
@@ -816,6 +863,7 @@ export const getObjectFormItemsDraft = ({
             isEdit,
             expandedControls,
             persistedControls,
+            sortPaths,
             urlParams,
           })
         }
@@ -848,6 +896,7 @@ export const getObjectFormItemsDraft = ({
                 isEdit,
                 expandedControls,
                 persistedControls,
+                sortPaths,
                 urlParams,
               })
             : undefined
@@ -901,6 +950,7 @@ export const getObjectFormItemsDraft = ({
             isEdit,
             expandedControls,
             persistedControls,
+            sortPaths,
             urlParams,
           })
         }
@@ -929,6 +979,7 @@ export const getObjectFormItemFromSwagger = ({
   isEdit,
   expandedControls,
   persistedControls,
+  sortPaths,
   urlParams,
   onRemoveByMinus,
 }: {
@@ -966,6 +1017,7 @@ export const getObjectFormItemFromSwagger = ({
   isEdit: boolean
   expandedControls: TExpandedControls
   persistedControls: TPersistedControls
+  sortPaths?: string[][]
   urlParams: TUrlParams
   onRemoveByMinus?: () => void
 }) => {
@@ -986,6 +1038,7 @@ export const getObjectFormItemFromSwagger = ({
     isEdit,
     expandedControls,
     persistedControls,
+    sortPaths,
     urlParams,
   })
   return (

--- a/src/components/molecules/BlackholeForm/organisms/BlackholeFormDataProvider/BlackholeFormDataProvider.tsx
+++ b/src/components/molecules/BlackholeForm/organisms/BlackholeFormDataProvider/BlackholeFormDataProvider.tsx
@@ -67,6 +67,7 @@ export const BlackholeFormDataProvider: FC<TBlackholeFormDataProviderProps> = ({
     hiddenPaths?: string[][]
     expandedPaths: string[][]
     persistedPaths: string[][]
+    sortPaths?: string[][]
     kindName: string
     isNamespaced?: boolean
     isError?: boolean
@@ -108,6 +109,7 @@ export const BlackholeFormDataProvider: FC<TBlackholeFormDataProviderProps> = ({
             hiddenPaths: data.hiddenPaths,
             expandedPaths: data.expandedPaths || [],
             persistedPaths: data.persistedPaths || [],
+            sortPaths: data.sortPaths,
             kindName: data.kindName || '',
             formPrefills: data.formPrefills,
             namespacesData: data.namespacesData,
@@ -167,6 +169,7 @@ export const BlackholeFormDataProvider: FC<TBlackholeFormDataProviderProps> = ({
       hiddenPaths={preparedData.hiddenPaths}
       expandedPaths={preparedData.expandedPaths}
       persistedPaths={preparedData.persistedPaths}
+      sortPaths={preparedData.sortPaths}
       prefillValuesSchema={data.prefillValuesSchema}
       prefillValueNamespaceOnly={data.prefillValueNamespaceOnly}
       isCreate={isCreate}

--- a/src/localTypes/bff/form.ts
+++ b/src/localTypes/bff/form.ts
@@ -41,6 +41,7 @@ export type TPrepareFormRes =
       hiddenPaths: string[][] | undefined
       expandedPaths: string[][] | undefined
       persistedPaths: string[][] | undefined
+      sortPaths: string[][] | undefined
       kindName: string | undefined
       isNamespaced: boolean
       formPrefills?: TFormPrefill


### PR DESCRIPTION
Link https://github.com/PRO-Robotech/openapi-ui-k8s-bff/pull/42

Screenshot:

<img width="1146" height="1227" alt="Screenshot 2025-09-23 at 17 50 35" src="https://github.com/user-attachments/assets/cf7003bc-af8e-4652-9706-514565c9e313" />

Example resource:

```yaml
apiVersion: dashboard.cozystack.io/v1alpha1
kind: CustomFormsOverride
metadata:
  name: apps.cozystack.io.v1alpha1.virtualmachines
spec:
  customizationId: default-/apps.cozystack.io/v1alpha1/virtualmachines
  hidden:
  - - metadata
    - annotations
  - - metadata
    - labels
  - - metadata
    - namespace
  - - metadata
    - creationTimestamp
  - - metadata
    - deletionGracePeriodSeconds
  - - metadata
    - deletionTimestamp
  - - metadata
    - finalizers
  - - metadata
    - generateName
  - - metadata
    - generation
  - - metadata
    - managedFields
  - - metadata
    - ownerReferences
  - - metadata
    - resourceVersion
  - - metadata
    - selfLink
  - - metadata
    - uid
  - - kind
  - - apiVersion
  - - appVersion
  - - status
  sort:
  - - apiVersion
  - - appVersion
  - - kind
  - - metadata
  - - metadata
    - name
  - - spec
  - - spec
    - external
  - - spec
    - externalMethod
  - - spec
    - externalPorts
  - - spec
    - running
  - - spec
    - instanceType
  - - spec
    - instanceProfile
  - - spec
    - systemDisk
  - - spec
    - systemDisk
    - image
  - - spec
    - systemDisk
    - storage
  - - spec
    - systemDisk
    - storageClass
  - - spec
    - gpus
  - - spec
    - resources
  - - spec
    - sshKeys
  - - spec
    - cloudInit
  - - spec
    - cloudInitSeed
  - - spec
    - cloudInitSeed
    - schema
  - - spec
    - cloudInitSeed
```

