### PR TITLE
fix(form): fix FormListInput value binding for Select component

### DIFF
--- a/src/components/molecules/BlackholeForm/molecules/FormListInput/FormListInput.tsx
+++ b/src/components/molecules/BlackholeForm/molecules/FormListInput/FormListInput.tsx
@@ -259,14 +259,15 @@ export const FormListInput: FC<TFormListInputProps> = ({
           <PersistedCheckbox formName={persistName || name} persistedControls={persistedControls} type="arr" />
         </Flex>
       </Flex>
-      <ResetedFormItem
-        key={arrKey !== undefined ? arrKey : Array.isArray(name) ? name.slice(-1)[0] : name}
-        name={arrName || fixedName}
-        rules={[getRequiredRule(forceNonRequired === false && !!required?.includes(getStringByName(name)), name)]}
-        validateTrigger="onBlur"
-        hasFeedback={designNewLayout ? { icons: feedbackIcons } : true}
-      >
-        <Flex gap={8} align="center">
+      <Flex gap={8} align="center">
+        <ResetedFormItem
+          key={arrKey !== undefined ? arrKey : Array.isArray(name) ? name.slice(-1)[0] : name}
+          name={arrName || fixedName}
+          rules={[getRequiredRule(forceNonRequired === false && !!required?.includes(getStringByName(name)), name)]}
+          validateTrigger="onBlur"
+          hasFeedback={designNewLayout ? { icons: feedbackIcons } : true}
+          style={{ flex: 1 }}
+        >
           <Select
             mode={customProps.mode}
             placeholder="Select"
@@ -277,13 +278,13 @@ export const FormListInput: FC<TFormListInputProps> = ({
             showSearch
             style={{ width: '100%' }}
           />
-          {relatedValueTooltip && (
-            <Tooltip title={relatedValueTooltip}>
-              <QuestionCircleOutlined />
-            </Tooltip>
-          )}
-        </Flex>
-      </ResetedFormItem>
+        </ResetedFormItem>
+        {relatedValueTooltip && (
+          <Tooltip title={relatedValueTooltip}>
+            <QuestionCircleOutlined />
+          </Tooltip>
+        )}
+      </Flex>
     </HiddenContainer>
   )
 }


### PR DESCRIPTION
## Summary

- Fix Select component not receiving form value/onChange bindings in FormListInput
- Ant Design's `Form.Item` passes `value`/`onChange` to its direct child via `React.cloneElement` — the intermediate `Flex` wrapper was intercepting them instead of `Select`
- Move `Flex` layout wrapper outside `ResetedFormItem` so `Select` becomes the direct child and receives form bindings correctly

## Context

This issue was discovered while working on API-backed dropdown selects for the [cozystack](https://github.com/cozystack/cozystack) dashboard — see cozystack/cozystack#2071.

The `FormListInput` component rendered correctly, but the selected value was never bound to the form state. Root cause: `ResetedFormItem` wraps `Form.Item`, which relies on `React.cloneElement` to inject `value`/`onChange` into its **direct child**. With `Flex` as the direct child, those props were passed to `Flex` (which ignores them) instead of `Select`.

Example CustomFormsOverride resource:
```yaml
apiVersion: dashboard.cozystack.io/v1alpha1
kind: CustomFormsOverride
metadata:
  labels:
    dashboard.cozystack.io/crd-group: apps.cozystack.io
    dashboard.cozystack.io/crd-kind: VMInstance
    dashboard.cozystack.io/crd-name: vm-instance
    dashboard.cozystack.io/crd-plural: vminstances
    dashboard.cozystack.io/crd-version: v1alpha1
    dashboard.cozystack.io/managed-by: cozystack-dashboard-controller
    dashboard.cozystack.io/resource-type: dynamic
  name: apps.cozystack.io.v1alpha1.vminstances
  ownerReferences:
    - apiVersion: cozystack.io/v1alpha1
      kind: ApplicationDefinition
      name: vm-instance
      uid: 871606bb-1ea7-4296-9870-6547948de582
spec:
  customizationId: default-/apps.cozystack.io/v1alpha1/vminstances
  hidden:
    - - metadata
      - annotations
    - - metadata
      - labels
    - - metadata
      - namespace
    - - metadata
      - creationTimestamp
    - - metadata
      - deletionGracePeriodSeconds
    - - metadata
      - deletionTimestamp
    - - metadata
      - finalizers
    - - metadata
      - generateName
    - - metadata
      - generation
    - - metadata
      - managedFields
    - - metadata
      - ownerReferences
    - - metadata
      - resourceVersion
    - - metadata
      - selfLink
    - - metadata
      - uid
    - - kind
    - - apiVersion
    - - appVersion
    - - status
  schema:
    properties:
      spec:
        properties:
          disks:
            items:
              properties:
                name:
                  customProps:
                    keysToLabel:
                      - metadata
                      - name
                    keysToValue:
                      - metadata
                      - name
                    valueUri: /api/clusters/{cluster}/k8s/apis/apps.cozystack.io/v1alpha1/namespaces/{namespace}/vmdisks
                  type: listInput
          instanceType:
            customProps:
              keysToLabel:
                - metadata
                - name
              keysToValue:
                - metadata
                - name
              valueUri: /api/clusters/{cluster}/k8s/apis/instancetype.kubevirt.io/v1beta1/virtualmachineclusterinstancetypes
            default: u1.medium
            type: listInput
  sort:
    - - apiVersion
    - - appVersion
    - - kind
    - - metadata
    - - metadata
      - name
    - - spec
      - external
    - - spec
      - externalMethod
    - - spec
      - externalPorts
    - - spec
      - runStrategy
    - - spec
      - instanceType
    - - spec
      - instanceProfile
    - - spec
      - disks
    - - spec
      - subnets
    - - spec
      - gpus
    - - spec
      - cpuModel
    - - spec
      - resources
    - - spec
      - sshKeys
    - - spec
      - cloudInit
    - - spec
      - cloudInitSeed
  strategy: merge
```
