### PR TITLE
fix(SecretBase64Plain): preserve newlines when copying with keyboard shortcut

### DIFF
--- a/src/components/organisms/DynamicComponents/molecules/SecretBase64Plain/SecretBase64Plain.tsx
+++ b/src/components/organisms/DynamicComponents/molecules/SecretBase64Plain/SecretBase64Plain.tsx
@@ -145,6 +145,12 @@ export const SecretBase64Plain: FC<{ data: TDynamicComponentsAppTypeMap['SecretB
               <Styled.DisabledInput
                 $hidden={effectiveHidden}
                 onClick={e => handleInputClick(e, effectiveHidden, value)}
+                onCopy={e => {
+                  if (!effectiveHidden) {
+                    e.preventDefault()
+                    e.clipboardData?.setData('text/plain', value)
+                  }
+                }}
                 value={shownValue}
                 readOnly
               />
@@ -161,6 +167,12 @@ export const SecretBase64Plain: FC<{ data: TDynamicComponentsAppTypeMap['SecretB
             <Styled.DisabledInput
               $hidden={effectiveHidden}
               onClick={e => handleInputClick(e, effectiveHidden, value)}
+              onCopy={e => {
+                if (!effectiveHidden) {
+                  e.preventDefault()
+                  e.clipboardData?.setData('text/plain', value)
+                }
+              }}
               value={shownValue}
               readOnly
             />


### PR DESCRIPTION
## Problem

When a user reveals a secret and copies it with Cmd+C/Ctrl+C (by first
clicking the field to select all text, then pressing the shortcut), the
value is pasted as a single line without newlines. This breaks multiline
values like kubeconfigs and certificates.

The root cause: `<input type="text">` strips newline characters. The
browser copies what the element "sees" — a flattened single-line string.

## Fix

Add an `onCopy` event handler to both `DisabledInput` instances inside
`renderSecretField`. The handler intercepts the native copy event, cancels
it, and writes the actual decoded value with preserved newlines to the
clipboard via `e.clipboardData.setData('text/plain', value)`.

The synchronous `clipboardData.setData()` API is required here (as opposed
to the async `navigator.clipboard.writeText()` used in the click handler)
because `clipboardData` is only valid during the event callback.

## Unchanged paths

- Copy button (`onClick` → `navigator.clipboard.writeText`) — already works correctly
- `DisabledTextArea` (`multiline` mode) — `<textarea>` preserves newlines natively