### PR TITLE
feat(FormListInput): add allowEmpty and persistType props

### DIFF
--- a/src/components/molecules/BlackholeForm/molecules/FormListInput/FormListInput.tsx
+++ b/src/components/molecules/BlackholeForm/molecules/FormListInput/FormListInput.tsx
@@ -148,6 +148,13 @@ export const FormListInput: FC<TFormListInputProps> = ({
     }
   }, [relatedPath, form, arrName, fixedName, relatedFieldValue, onValuesChangeCallBack, isTouchedPeristed])
 
+  // When allowEmpty is set, auto-persist the field so the BFF preserves empty values
+  useEffect(() => {
+    if (customProps.allowEmpty) {
+      persistedControls.onPersistMark(persistName || name, customProps.persistType ?? 'str')
+    }
+  }, [customProps.allowEmpty, customProps.persistType, persistedControls, persistName, name])
+
   const uri = prepareTemplate({
     template: customProps.valueUri,
     replaceValues: { cluster, namespace, syntheticProject, relatedFieldValue, name: entryName },
@@ -267,6 +274,15 @@ export const FormListInput: FC<TFormListInputProps> = ({
           validateTrigger="onBlur"
           hasFeedback={designNewLayout ? { icons: feedbackIcons } : true}
           style={{ flex: 1 }}
+          normalize={(value: unknown) => {
+            if (customProps.allowEmpty && (value === undefined || value === null)) {
+              if (customProps.persistType === 'number') return 0
+              if (customProps.persistType === 'arr') return []
+              if (customProps.persistType === 'obj') return {}
+              return ''
+            }
+            return value
+          }}
         >
           <Select
             mode={customProps.mode}

--- a/src/localTypes/formExtensions.ts
+++ b/src/localTypes/formExtensions.ts
@@ -57,4 +57,6 @@ export type TListInputCustomProps = {
     keepPrefilled?: boolean
   }
   relatedValuePath?: string
+  allowEmpty?: boolean
+  persistType?: 'str' | 'number' | 'arr' | 'obj'
 }


### PR DESCRIPTION
## What

When a `listInput` field has a schema default value, clearing the selection
in the form UI silently reverts to the default — making it impossible to
explicitly send an empty value to the API.

## Changes

Add two new optional props to `TListInputCustomProps`:

- **`allowEmpty`** — when set, auto-persists the field via `onPersistMark`
  so the BFF includes the field in the payload even when the user clears it
- **`persistType`** (`'str' | 'number' | 'arr' | 'obj'`) — controls the
  type of empty value returned by the `normalize` function; defaults to
  `'str'` so all existing usages are unaffected

## Usage

```ts
{
  type: 'listInput',
  customProps: {
    valueUri: '/api/...',
    keysToValue: ['metadata', 'name'],
    allowEmpty: true,
    // persistType: 'str' // default
  }
}
```