### PR TITLE
[CLOUD-480]: fix timing gap

### DIFF
--- a/src/components/organisms/DynamicRendererWithProviders/providers/hybridDataProvider/hybridDataProvider.test.tsx
+++ b/src/components/organisms/DynamicRendererWithProviders/providers/hybridDataProvider/hybridDataProvider.test.tsx
@@ -16,9 +16,9 @@ jest.mock('@tanstack/react-query', () => {
   }
 })
 
-const useK8sSmartResourceMock = jest.fn()
+const useManyK8sSmartResourceMock = jest.fn()
 jest.mock('hooks/useK8sSmartResource', () => ({
-  useK8sSmartResource: (args: any) => useK8sSmartResourceMock(args),
+  useManyK8sSmartResource: (args: any) => useManyK8sSmartResourceMock(args),
 }))
 
 // -------------------- test helpers --------------------
@@ -61,65 +61,23 @@ const Output = () => {
 }
 
 /**
- * Two-phase stable K8s mock:
- * For each distinct params.id:
- *  - 1st call returns base
- *  - 2nd call returns base with a NEW ref for data if it's an object
- *    and a NEW ref for error if it's an object (e.g., Error)
- *
- * This causes K8sFetcher useEffect deps to change once after RESET,
- * letting it re-dispatch SET_ENTRY.
+ * Helper: create a useManyK8sSmartResource mock that returns results
+ * based on each item's `id` field.
  */
-const makeTwoPhaseK8sMock = (
+const makeK8sResultsMock = (
   byId: Record<string, { data: any; isLoading?: boolean; isError?: boolean; error?: any }>,
 ) => {
-  const counters = new Map<string, number>()
-  const secondDataRefs = new Map<string, any>()
-  const secondErrRefs = new Map<string, any>()
-
-  return (params: any) => {
-    const id = params?.id ?? 'unknown'
-    const base = byId[id] ?? { data: undefined, isLoading: false, isError: false, error: null }
-
-    const n = (counters.get(id) ?? 0) + 1
-    counters.set(id, n)
-
-    const isLoading = base.isLoading ?? false
-    const isError = base.isError ?? false
-    const error = base.error ?? null
-
-    if (n === 1) {
-      return { data: base.data, isLoading, isError, error }
-    }
-
-    // second-phase data ref
-    if (!secondDataRefs.has(id)) {
-      const d = base.data
-      secondDataRefs.set(id, d && typeof d === 'object' ? { ...d } : d)
-    }
-
-    // second-phase error ref
-    if (!secondErrRefs.has(id)) {
-      const e = error
-
-      if (e instanceof Error) {
-        // new ref + preserves message
-        secondErrRefs.set(id, new Error(e.message))
-      } else if (e && typeof e === 'object') {
-        // best-effort clone for AxiosError-like objects
-        secondErrRefs.set(id, { ...(e as any) })
-      } else {
-        secondErrRefs.set(id, e)
+  return (paramsList: any[]) =>
+    paramsList.map((params: any) => {
+      const id = params?.id ?? 'unknown'
+      const base = byId[id] ?? { data: undefined, isLoading: false, isError: false, error: undefined }
+      return {
+        data: base.data,
+        isLoading: base.isLoading ?? false,
+        isError: base.isError ?? false,
+        error: base.error ?? undefined,
       }
-    }
-
-    return {
-      data: secondDataRefs.get(id),
-      isLoading,
-      isError,
-      error: secondErrRefs.get(id),
-    }
-  }
+    })
 }
 
 const makeStableUrlResults = (...results: any[]) =>
@@ -156,8 +114,8 @@ describe('MultiQueryProvider / useMultiQuery', () => {
     const u1Data = { u: 1 }
     const u2Data = { u: 2 }
 
-    useK8sSmartResourceMock.mockImplementation(
-      makeTwoPhaseK8sMock({
+    useManyK8sSmartResourceMock.mockImplementation(
+      makeK8sResultsMock({
         k1: { data: k1Data },
         k2: { data: k2Data },
       }),
@@ -200,8 +158,8 @@ describe('MultiQueryProvider / useMultiQuery', () => {
     const k2Data = { k: 2 }
     const u1Data = { u: 1 }
 
-    useK8sSmartResourceMock.mockImplementation(
-      makeTwoPhaseK8sMock({
+    useManyK8sSmartResourceMock.mockImplementation(
+      makeK8sResultsMock({
         k1: { data: k1Data },
         k2: { data: k2Data },
       }),
@@ -230,11 +188,8 @@ describe('MultiQueryProvider / useMultiQuery', () => {
   })
 
   test('isLoading true if any K8s entry is loading', async () => {
-    // IMPORTANT:
-    // Provide a real object for data so the two-phase mock can change refs
-    // and re-trigger K8sFetcher effect after RESET.
-    useK8sSmartResourceMock.mockImplementation(
-      makeTwoPhaseK8sMock({
+    useManyK8sSmartResourceMock.mockImplementation(
+      makeK8sResultsMock({
         k1: { data: { k: 1 }, isLoading: true },
         k2: { data: { k: 2 }, isLoading: false },
       }),
@@ -254,8 +209,8 @@ describe('MultiQueryProvider / useMultiQuery', () => {
   })
 
   test('isLoading true if any URL query is loading', async () => {
-    useK8sSmartResourceMock.mockImplementation(
-      makeTwoPhaseK8sMock({
+    useManyK8sSmartResourceMock.mockImplementation(
+      makeK8sResultsMock({
         k1: { data: { k: 1 } },
       }),
     )
@@ -276,10 +231,8 @@ describe('MultiQueryProvider / useMultiQuery', () => {
   })
 
   test('isError true and errors array populated when any K8s entry errors', async () => {
-    // IMPORTANT:
-    // Use Error object so two-phase can change error ref after RESET.
-    useK8sSmartResourceMock.mockImplementation(
-      makeTwoPhaseK8sMock({
+    useManyK8sSmartResourceMock.mockImplementation(
+      makeK8sResultsMock({
         k1: { data: { k: 1 }, isError: true, error: new Error('k8s boom') },
         k2: { data: { k: 2 }, isError: false },
       }),
@@ -302,8 +255,8 @@ describe('MultiQueryProvider / useMultiQuery', () => {
   })
 
   test('isError true and errors array populated when any URL query errors', async () => {
-    useK8sSmartResourceMock.mockImplementation(
-      makeTwoPhaseK8sMock({
+    useManyK8sSmartResourceMock.mockImplementation(
+      makeK8sResultsMock({
         k1: { data: { k: 1 } },
       }),
     )
@@ -331,6 +284,7 @@ describe('MultiQueryProvider / useMultiQuery', () => {
   })
 
   test('handles empty items list', () => {
+    useManyK8sSmartResourceMock.mockImplementation(() => [])
     useQueriesMock.mockImplementation(() => [])
 
     render(

--- a/src/components/organisms/DynamicRendererWithProviders/providers/hybridDataProvider/hybridDataProvider.tsx
+++ b/src/components/organisms/DynamicRendererWithProviders/providers/hybridDataProvider/hybridDataProvider.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable react-hooks/exhaustive-deps */
-import React, { FC, ReactNode, createContext, useContext, useEffect, useMemo, useReducer } from 'react'
+import React, { FC, ReactNode, createContext, useContext, useMemo } from 'react'
 import axios, { AxiosError } from 'axios'
 import { useQueries } from '@tanstack/react-query'
-import { TUseK8sSmartResourceParams, useK8sSmartResource } from 'hooks/useK8sSmartResource'
+import { TUseK8sSmartResourceParams, useManyK8sSmartResource } from 'hooks/useK8sSmartResource'
 
 type DataMap = Record<string, unknown>
 
@@ -23,66 +22,6 @@ type MultiQueryProviderProps = {
   children: ReactNode
 }
 
-/** ---------------- Aggregation for K8s branch --------------------------- */
-
-type ResultEntry = {
-  data: unknown
-  isLoading: boolean
-  isError: boolean
-  error: AxiosError | Error | string | null
-}
-
-type AggState = { entries: ResultEntry[] }
-type AggAction = { type: 'RESET'; total: number } | { type: 'SET_ENTRY'; index: number; entry: ResultEntry }
-
-const makeEmptyEntry = (): ResultEntry => ({
-  data: undefined,
-  isLoading: false,
-  isError: false,
-  error: null,
-})
-
-const aggReducer = (state: AggState, action: AggAction): AggState => {
-  switch (action.type) {
-    case 'RESET':
-      return { entries: Array.from({ length: action.total }, makeEmptyEntry) }
-    case 'SET_ENTRY': {
-      const entries = state.entries.slice()
-      entries[action.index] = action.entry
-      return { entries }
-    }
-    default:
-      return state
-  }
-}
-
-/** ----------------- Child allowed to call the K8s hook ------------------- */
-
-type K8sFetcherProps = {
-  index: number // index within the K8s subset (0..k8sCount-1)
-  params: TUseK8sSmartResourceParams<unknown>
-  dispatch: React.Dispatch<AggAction>
-}
-
-const K8sFetcher: FC<K8sFetcherProps> = ({ index, params, dispatch }) => {
-  const res = useK8sSmartResource<unknown>(params)
-
-  useEffect(() => {
-    dispatch({
-      type: 'SET_ENTRY',
-      index,
-      entry: {
-        data: res.data,
-        isLoading: res.isLoading,
-        isError: res.isError,
-        error: (res.error as AxiosError | Error | string | undefined) ?? null,
-      },
-    })
-  }, [index, res.data, res.isLoading, res.isError, res.error, dispatch])
-
-  return null
-}
-
 /** ------------------------------ Provider -------------------------------- */
 
 export const MultiQueryProvider: FC<MultiQueryProviderProps> = ({ items, dataToApplyToContext, children }) => {
@@ -96,13 +35,9 @@ export const MultiQueryProvider: FC<MultiQueryProviderProps> = ({ items, dataToA
   const k8sCount = k8sItems.length
   const urlCount = urlItems.length
 
-  // Aggregator for K8s subset only
-  const [state, dispatch] = useReducer(aggReducer, { entries: Array.from({ length: k8sCount }, makeEmptyEntry) })
-
-  // Reset when K8s count changes
-  useEffect(() => {
-    dispatch({ type: 'RESET', total: k8sCount })
-  }, [k8sCount])
+  // Direct hook call — replaces K8sFetcher + useReducer + useEffect bridge
+  // Data is available synchronously in the same render frame (no 1-frame lag)
+  const k8sResults = useManyK8sSmartResource(k8sItems)
 
   // URL queries for the URL subset only
   const urlQueries = useQueries({
@@ -119,10 +54,6 @@ export const MultiQueryProvider: FC<MultiQueryProviderProps> = ({ items, dataToA
 
   // Assemble context value
   const value: MultiQueryContextValue = (() => {
-    // if (typeof dataToApplyToContext !== 'undefined') {
-    //   return { data: { req0: dataToApplyToContext }, isLoading: false, isError: false, errors: [] }
-    // }
-
     const data: DataMap = {}
     const errors: Array<AxiosError | Error | string | null> = []
 
@@ -130,22 +61,17 @@ export const MultiQueryProvider: FC<MultiQueryProviderProps> = ({ items, dataToA
     const hasExtraReq0 = typeof dataToApplyToContext !== 'undefined'
     const baseIndex = hasExtraReq0 ? 1 : 0
 
-    // 1) K8s occupy req[0..k8sCount-1]
+    // 1) K8s results from useManyK8sSmartResource (synchronous, no useEffect delay)
     for (let i = 0; i < k8sCount; i++) {
-      const e = state.entries[i] ?? makeEmptyEntry()
-      // data[`req${i}`] = e.data
-      // errors[i] = e.isError ? e.error : null
+      const result = k8sResults[i]
       const idx = baseIndex + i
-      data[`req${idx}`] = e.data
-      errors[idx] = e.isError ? e.error : null
+      data[`req${idx}`] = result?.data
+      errors[idx] = result?.isError ? ((result.error ?? null) as AxiosError | Error | string | null) : null
     }
 
     // 2) URLs continue after K8s: req[k8sCount..total-1]
     for (let i = 0; i < urlCount; i++) {
       const q = urlQueries[i]
-      // const idx = k8sCount + i
-      // data[`req${idx}`] = q?.data
-      // errors[idx] = q?.isError ? ((q.error ?? null) as AxiosError | Error | string | null) : null
       const idx = baseIndex + k8sCount + i
       data[`req${idx}`] = q?.data
       errors[idx] = q?.isError ? ((q.error ?? null) as AxiosError | Error | string | null) : null
@@ -158,23 +84,14 @@ export const MultiQueryProvider: FC<MultiQueryProviderProps> = ({ items, dataToA
       errors[0] = null
     }
 
-    const isLoading = state.entries.some(e => e.isLoading) || urlQueries.some(q => q.isLoading)
+    const isLoading = k8sResults.some(r => r.isLoading) || urlQueries.some(q => q.isLoading)
 
-    const isError = state.entries.some(e => e.isError) || urlQueries.some(q => q.isError)
+    const isError = k8sResults.some(r => r.isError) || urlQueries.some(q => q.isError)
 
     return { data, isLoading, isError, errors }
   })()
 
-  return (
-    <MultiQueryContext.Provider value={value}>
-      {/* Mount one fetcher per K8s resource (Rules of Hooks compliant) */}
-      {k8sItems.map((params, i) => (
-        // eslint-disable-next-line react/no-array-index-key
-        <K8sFetcher key={i} index={i} params={params} dispatch={dispatch} />
-      ))}
-      {children}
-    </MultiQueryContext.Provider>
-  )
+  return <MultiQueryContext.Provider value={value}>{children}</MultiQueryContext.Provider>
 }
 
 /** Consumer hook */


### PR DESCRIPTION
Fix 1-frame timing gap in `MultiQueryProvider` where `isLoading` was falsely `false` while K8s data was still `undefined`, causing `parseAll` templates to resolve with fallback values (-) on initial render. Replaced the `K8sFetcher` child component + `useReducer` + `useEffect` bridge with a direct `useManyK8sSmartResource()` call, making K8s data available synchronously in the same render frame.