### PR TITLE
[CLOUD-251]: Support item-level wildcard prefills (wildcard * as last path segment)

### DIFF
--- a/src/components/molecules/BlackholeForm/organisms/BlackholeForm/BlackholeForm.tsx
+++ b/src/components/molecules/BlackholeForm/organisms/BlackholeForm/BlackholeForm.tsx
@@ -437,7 +437,11 @@ export const BlackholeForm: FC<TBlackholeFormProps> = ({
         const current = form.getFieldValue(concretePath as any)
         dbg('current value at path', concretePath, ':', current)
 
-        if (typeof current === 'undefined') {
+        const isItemLevelWildcard = tpl.wildcardPath[tpl.wildcardPath.length - 1] === '*'
+        const isEffectivelyEmpty =
+          typeof current === 'undefined' || (isItemLevelWildcard && _.isPlainObject(current) && _.isEmpty(current))
+
+        if (isEffectivelyEmpty) {
           const toSet = _.cloneDeep(tpl.value)
           dbg('setting value', { path: concretePath, value: toSet })
           form.setFieldValue(concretePath as any, toSet)


### PR DESCRIPTION
Fix item-level wildcard CFP prefills where the wildcard `*` is the last path segment (e.g., `[spec, ports, *]` with an object value). Previously, the form framework pre-initialized new array slots as `{}`, causing the typeof current === 'undefined' guard to skip the prefill. The fix relaxes the check to also treat empty plain objects as "effectively empty" when the wildcard is at the item level. 