### PR TITLE
[CLOUD-485]: AntdResult status auto-detect mode

### DIFF
--- a/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.stories.tsx
+++ b/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.stories.tsx
@@ -14,7 +14,7 @@ type TInner = TDynamicComponentsAppTypeMap['antdResult']
 type TProviderArgs = {
   isLoading: boolean
   isError: boolean
-  errors: { message: string }[]
+  errors: ({ message: string } | null)[]
   multiQueryData: Record<string, unknown> | null
   partsOfUrl: string[]
 }
@@ -26,10 +26,11 @@ const meta: Meta<TArgs> = {
   component: AntdResult as any,
   argTypes: {
     id: { control: 'text', description: 'data.id' },
+    reqIndex: { control: 'number', description: 'data.reqIndex — auto-detect error from this request index' },
     status: {
       control: { type: 'select' },
-      options: ['success', 'error', 'info', 'warning', '403', '404', '500'],
-      description: 'data.status — Ant Design Result status',
+      options: [undefined, 'success', 'error', 'info', 'warning', '403', '404', '500'],
+      description: 'data.status — override or manual status',
     },
     title: { control: 'text', description: 'data.title (supports template syntax)' },
     subTitle: { control: 'text', description: 'data.subTitle (supports template syntax)' },
@@ -58,6 +59,7 @@ const meta: Meta<TArgs> = {
           <AntdResult
             data={{
               id: args.id,
+              reqIndex: args.reqIndex,
               status: args.status,
               title: args.title,
               subTitle: args.subTitle,
@@ -75,10 +77,11 @@ const meta: Meta<TArgs> = {
           type: 'antdResult',
           data: {
             id: args.id,
-            status: args.status,
-            title: args.title,
-            subTitle: args.subTitle,
-            style: args.style,
+            ...(args.reqIndex !== undefined && { reqIndex: args.reqIndex }),
+            ...(args.status && { status: args.status }),
+            ...(args.title && { title: args.title }),
+            ...(args.subTitle && { subTitle: args.subTitle }),
+            ...(args.style && { style: args.style }),
           },
         })}
         theme={'vs-dark'}
@@ -98,9 +101,12 @@ export default meta
 
 type Story = StoryObj<TArgs>
 
+// ── Manual mode stories ─────────────────────────────────────────
+
 export const NotFound: Story = {
   args: {
     id: 'result-404',
+    reqIndex: undefined,
     status: '404',
     title: 'Not Found',
     subTitle: 'The requested resource does not exist.',
@@ -163,6 +169,37 @@ export const WithTemplates: Story = {
     subTitle: 'Namespace: {0}',
     multiQueryData: { req0: { metadata: { name: 'my-pod-xyz' } } },
     partsOfUrl: ['default'],
+  },
+}
+
+// ── Auto-detect mode stories ────────────────────────────────────
+
+export const AutoDetectError: Story = {
+  name: 'Auto-detect: request failed',
+  args: {
+    id: 'result-auto-error',
+    reqIndex: 0,
+    status: undefined,
+    title: undefined,
+    subTitle: undefined,
+    style: undefined,
+
+    isLoading: false,
+    isError: true,
+    errors: [{ message: 'Request failed with status code 403' }],
+    multiQueryData: null,
+    partsOfUrl: [],
+  },
+}
+
+export const AutoDetectNoError: Story = {
+  name: 'Auto-detect: request succeeded (renders nothing)',
+  args: {
+    ...AutoDetectError.args,
+    id: 'result-auto-ok',
+    isError: false,
+    errors: [null],
+    multiQueryData: { req0: { metadata: { name: 'some-pod' } } },
   },
 }
 

--- a/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.tsx
+++ b/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.tsx
@@ -6,11 +6,27 @@ import { useMultiQuery } from '../../../DynamicRendererWithProviders/providers/h
 import { usePartsOfUrl } from '../../../DynamicRendererWithProviders/providers/partsOfUrlContext'
 import { parseAll } from '../utils'
 
+type TErrorWithResponse = { response?: { status?: number; statusText?: string }; message?: string }
+
+const httpStatusToResultStatus = (statusCode: number | undefined) => {
+  if (statusCode === 403) return '403' as const
+  if (statusCode === 404) return '404' as const
+  if (statusCode && statusCode >= 500) return '500' as const
+  return 'error' as const
+}
+
+const getDefaultTitle = (status: string | number) => {
+  if (status === '403') return 'Access Denied'
+  if (status === '404') return 'Not Found'
+  if (status === '500') return 'Server Error'
+  return 'Error'
+}
+
 export const AntdResult: FC<{
   data: TDynamicComponentsAppTypeMap['antdResult']
   children?: any
 }> = ({ data, children }) => {
-  const { data: multiQueryData, isLoading } = useMultiQuery()
+  const { data: multiQueryData, isLoading, errors } = useMultiQuery()
   const partsOfUrl = usePartsOfUrl()
 
   if (isLoading) {
@@ -22,6 +38,31 @@ export const AntdResult: FC<{
     return acc
   }, {})
 
+  // Auto-detect mode: reqIndex provided → check errors for that request
+  if (typeof data.reqIndex === 'number') {
+    const error = errors[data.reqIndex]
+
+    if (!error) {
+      return children ?? null
+    }
+
+    const errorObj = error as TErrorWithResponse
+    const httpStatus = errorObj?.response?.status
+    const autoStatus = httpStatusToResultStatus(httpStatus)
+    const autoMessage = errorObj?.response?.statusText || errorObj?.message || String(error)
+
+    const status = data.status ?? autoStatus
+    const title = data.title ? parseAll({ text: data.title, replaceValues, multiQueryData }) : getDefaultTitle(status)
+    const subTitle = data.subTitle ? parseAll({ text: data.subTitle, replaceValues, multiQueryData }) : autoMessage
+
+    return (
+      <Result status={status} title={title} subTitle={subTitle} style={data.style}>
+        {children}
+      </Result>
+    )
+  }
+
+  // Manual mode: no reqIndex → fully static/template-driven
   const parsedTitle = data.title ? parseAll({ text: data.title, replaceValues, multiQueryData }) : undefined
 
   const parsedSubTitle = data.subTitle ? parseAll({ text: data.subTitle, replaceValues, multiQueryData }) : undefined

--- a/src/components/organisms/DynamicComponents/types/antdComponents.ts
+++ b/src/components/organisms/DynamicComponents/types/antdComponents.ts
@@ -43,6 +43,7 @@ export type TAntdIconsProps = {
 
 export type TAntdResultProps = {
   id: number | string
+  reqIndex?: number
   status?: 'success' | 'error' | 'info' | 'warning' | '403' | '404' | '500' | 403 | 404 | 500
   title?: string
   subTitle?: string


### PR DESCRIPTION
Add auto-detect mode to `antdResult` factory molecule. When `reqIndex` is provided, the component reads the actual HTTP error from the corresponding `urlsToFetch` request and auto-renders the matching Result illustration (`403`/`404`/`500`).