### PR TITLE
[CLOUD-485]: emptyAsNotFound prop added

### DIFF
--- a/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.stories.tsx
+++ b/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.stories.tsx
@@ -27,6 +27,7 @@ const meta: Meta<TArgs> = {
   argTypes: {
     id: { control: 'text', description: 'data.id' },
     reqIndex: { control: 'number', description: 'data.reqIndex — auto-detect error from this request index' },
+    emptyAsNotFound: { control: 'boolean', description: 'data.emptyAsNotFound — treat empty K8s list as 404' },
     status: {
       control: { type: 'select' },
       options: [undefined, 'success', 'error', 'info', 'warning', '403', '404', '500'],
@@ -60,6 +61,7 @@ const meta: Meta<TArgs> = {
             data={{
               id: args.id,
               reqIndex: args.reqIndex,
+              emptyAsNotFound: args.emptyAsNotFound,
               status: args.status,
               title: args.title,
               subTitle: args.subTitle,
@@ -78,6 +80,7 @@ const meta: Meta<TArgs> = {
           data: {
             id: args.id,
             ...(args.reqIndex !== undefined && { reqIndex: args.reqIndex }),
+            ...(args.emptyAsNotFound && { emptyAsNotFound: args.emptyAsNotFound }),
             ...(args.status && { status: args.status }),
             ...(args.title && { title: args.title }),
             ...(args.subTitle && { subTitle: args.subTitle }),
@@ -200,6 +203,34 @@ export const AutoDetectNoError: Story = {
     isError: false,
     errors: [null],
     multiQueryData: { req0: { metadata: { name: 'some-pod' } } },
+  },
+}
+
+export const EmptyAsNotFound: Story = {
+  name: 'emptyAsNotFound: empty K8s list treated as 404',
+  args: {
+    id: 'result-empty-list',
+    reqIndex: 0,
+    emptyAsNotFound: true,
+    status: undefined,
+    title: 'Pod {0} is not found',
+    subTitle: 'Namespace: {1}',
+    style: undefined,
+
+    isLoading: false,
+    isError: false,
+    errors: [null],
+    multiQueryData: { req0: { items: [] } },
+    partsOfUrl: ['nginx-missing-pod', 'default'],
+  },
+}
+
+export const EmptyAsNotFoundDisabled: Story = {
+  name: 'emptyAsNotFound: disabled — empty list renders children',
+  args: {
+    ...EmptyAsNotFound.args,
+    id: 'result-empty-list-disabled',
+    emptyAsNotFound: false,
   },
 }
 

--- a/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.test.tsx
+++ b/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.test.tsx
@@ -91,7 +91,7 @@ describe('manual mode (no reqIndex)', () => {
 // ── Auto-detect mode (reqIndex provided) ───────────────────────
 
 describe('auto-detect mode (reqIndex)', () => {
-  it('renders children when request succeeded and data exists', () => {
+  it('renders children when request succeeded and data has items', () => {
     mockUseMultiQuery.mockReturnValue({
       data: { req0: { items: [{ metadata: { name: 'nginx' } }] } },
       isLoading: false,
@@ -108,7 +108,7 @@ describe('auto-detect mode (reqIndex)', () => {
     expect(screen.getByTestId('page-content')).toBeInTheDocument()
   })
 
-  it('renders null when no error and no children', () => {
+  it('renders null when no error, has items, and no children', () => {
     mockUseMultiQuery.mockReturnValue({
       data: { req0: { items: [{ metadata: { name: 'nginx' } }] } },
       isLoading: false,
@@ -169,10 +169,10 @@ describe('auto-detect mode (reqIndex)', () => {
   })
 })
 
-// ── emptyAsNotFound ────────────────────────────────────────────
+// ── checkEmpty (default: true) ────────────────────────────────
 
-describe('emptyAsNotFound', () => {
-  it('renders 404 Result when items is empty and flag is true', () => {
+describe('checkEmpty (default: true)', () => {
+  it('renders 404 Result when items is empty (default behavior)', () => {
     mockUseMultiQuery.mockReturnValue({
       data: { req0: { items: [] } },
       isLoading: false,
@@ -181,7 +181,7 @@ describe('emptyAsNotFound', () => {
     })
 
     render(
-      <AntdResult data={{ id: 'empty', reqIndex: 0, emptyAsNotFound: true }}>
+      <AntdResult data={{ id: 'empty-default', reqIndex: 0 }}>
         <div data-testid="should-not-render" />
       </AntdResult>,
     )
@@ -191,7 +191,7 @@ describe('emptyAsNotFound', () => {
     expect(screen.queryByTestId('should-not-render')).not.toBeInTheDocument()
   })
 
-  it('renders children when items is empty but flag is false', () => {
+  it('renders 404 Result when checkEmpty is explicitly true', () => {
     mockUseMultiQuery.mockReturnValue({
       data: { req0: { items: [] } },
       isLoading: false,
@@ -200,15 +200,16 @@ describe('emptyAsNotFound', () => {
     })
 
     render(
-      <AntdResult data={{ id: 'no-flag', reqIndex: 0, emptyAsNotFound: false }}>
-        <div data-testid="page-content">Should render</div>
+      <AntdResult data={{ id: 'empty-explicit', reqIndex: 0, checkEmpty: true }}>
+        <div data-testid="should-not-render" />
       </AntdResult>,
     )
 
-    expect(screen.getByTestId('page-content')).toBeInTheDocument()
+    expect(screen.getByText('Not Found')).toBeInTheDocument()
+    expect(screen.queryByTestId('should-not-render')).not.toBeInTheDocument()
   })
 
-  it('renders children when items is empty but flag is not set', () => {
+  it('renders children when items is empty but checkEmpty is false', () => {
     mockUseMultiQuery.mockReturnValue({
       data: { req0: { items: [] } },
       isLoading: false,
@@ -217,7 +218,7 @@ describe('emptyAsNotFound', () => {
     })
 
     render(
-      <AntdResult data={{ id: 'no-flag-default', reqIndex: 0 }}>
+      <AntdResult data={{ id: 'no-check', reqIndex: 0, checkEmpty: false }}>
         <div data-testid="page-content">Should render</div>
       </AntdResult>,
     )
@@ -225,7 +226,7 @@ describe('emptyAsNotFound', () => {
     expect(screen.getByTestId('page-content')).toBeInTheDocument()
   })
 
-  it('renders children when items has data and flag is true', () => {
+  it('renders children when items has data', () => {
     mockUseMultiQuery.mockReturnValue({
       data: { req0: { items: [{ metadata: { name: 'nginx' } }] } },
       isLoading: false,
@@ -234,7 +235,7 @@ describe('emptyAsNotFound', () => {
     })
 
     render(
-      <AntdResult data={{ id: 'has-data', reqIndex: 0, emptyAsNotFound: true }}>
+      <AntdResult data={{ id: 'has-data', reqIndex: 0 }}>
         <div data-testid="page-content">Pod exists</div>
       </AntdResult>,
     )
@@ -256,7 +257,6 @@ describe('emptyAsNotFound', () => {
         data={{
           id: 'custom-empty',
           reqIndex: 0,
-          emptyAsNotFound: true,
           status: 'warning',
           title: 'Pod {0} is not found',
           subTitle: 'Namespace: {1}',
@@ -268,7 +268,7 @@ describe('emptyAsNotFound', () => {
     expect(screen.getByText('Namespace: default')).toBeInTheDocument()
   })
 
-  it('prefers HTTP error over emptyAsNotFound when both apply', () => {
+  it('prefers HTTP error over empty check when both apply', () => {
     mockUseMultiQuery.mockReturnValue({
       data: { req0: { items: [] } },
       isLoading: false,
@@ -276,16 +276,90 @@ describe('emptyAsNotFound', () => {
       errors: [{ response: { status: 403, statusText: 'Forbidden' }, message: 'Forbidden' }],
     })
 
-    render(<AntdResult data={{ id: 'error-priority', reqIndex: 0, emptyAsNotFound: true }} />)
+    render(<AntdResult data={{ id: 'error-priority', reqIndex: 0 }} />)
 
     expect(screen.getByText('Access Denied')).toBeInTheDocument()
     expect(screen.getByText('Forbidden')).toBeInTheDocument()
   })
 })
 
-// ── isEmptyK8sList edge cases ──────────────────────────────────
+// ── Custom itemsPath ─────────────────────────────────────────
 
-describe('isEmptyK8sList edge cases', () => {
+describe('custom itemsPath', () => {
+  it('checks emptiness at a custom path (non-K8s API)', () => {
+    mockUseMultiQuery.mockReturnValue({
+      data: { req0: { data: { results: [] } } },
+      isLoading: false,
+      isError: false,
+      errors: [null],
+    })
+
+    render(
+      <AntdResult data={{ id: 'custom-path', reqIndex: 0, itemsPath: '.data.results' }}>
+        <div data-testid="should-not-render" />
+      </AntdResult>,
+    )
+
+    expect(screen.getByText('Not Found')).toBeInTheDocument()
+    expect(screen.queryByTestId('should-not-render')).not.toBeInTheDocument()
+  })
+
+  it('renders children when custom path has data', () => {
+    mockUseMultiQuery.mockReturnValue({
+      data: { req0: { data: { results: [{ id: 1 }] } } },
+      isLoading: false,
+      isError: false,
+      errors: [null],
+    })
+
+    render(
+      <AntdResult data={{ id: 'custom-path-ok', reqIndex: 0, itemsPath: '.data.results' }}>
+        <div data-testid="page-content">Has results</div>
+      </AntdResult>,
+    )
+
+    expect(screen.getByTestId('page-content')).toBeInTheDocument()
+  })
+
+  it('renders children when custom path does not exist in response', () => {
+    mockUseMultiQuery.mockReturnValue({
+      data: { req0: { something: 'else' } },
+      isLoading: false,
+      isError: false,
+      errors: [null],
+    })
+
+    render(
+      <AntdResult data={{ id: 'missing-path', reqIndex: 0, itemsPath: '.data.results' }}>
+        <div data-testid="page-content">Path not found in response</div>
+      </AntdResult>,
+    )
+
+    expect(screen.getByTestId('page-content')).toBeInTheDocument()
+  })
+
+  it('does not check default .items when custom path is set', () => {
+    mockUseMultiQuery.mockReturnValue({
+      data: { req0: { items: [], data: { results: [{ id: 1 }] } } },
+      isLoading: false,
+      isError: false,
+      errors: [null],
+    })
+
+    render(
+      <AntdResult data={{ id: 'custom-ignores-default', reqIndex: 0, itemsPath: '.data.results' }}>
+        <div data-testid="page-content">items is empty but we check results</div>
+      </AntdResult>,
+    )
+
+    // .items is empty, but we're checking .data.results which has data → children render
+    expect(screen.getByTestId('page-content')).toBeInTheDocument()
+  })
+})
+
+// ── isEmptyAtPath edge cases ─────────────────────────────────
+
+describe('isEmptyAtPath edge cases', () => {
   it.each([
     ['null reqData', { req0: null }],
     ['undefined reqData', {}],
@@ -302,7 +376,7 @@ describe('isEmptyK8sList edge cases', () => {
     })
 
     render(
-      <AntdResult data={{ id: 'edge', reqIndex: 0, emptyAsNotFound: true }}>
+      <AntdResult data={{ id: 'edge', reqIndex: 0 }}>
         <div data-testid="page-content">Should render</div>
       </AntdResult>,
     )

--- a/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.test.tsx
+++ b/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.test.tsx
@@ -357,30 +357,4 @@ describe('custom itemsPath', () => {
   })
 })
 
-// ── isEmptyAtPath edge cases ─────────────────────────────────
-
-describe('isEmptyAtPath edge cases', () => {
-  it.each([
-    ['null reqData', { req0: null }],
-    ['undefined reqData', {}],
-    ['non-object reqData', { req0: 'string-value' }],
-    ['reqData without items key', { req0: { metadata: {} } }],
-    ['items is not an array', { req0: { items: 'not-array' } }],
-    ['items is an object', { req0: { items: {} } }],
-  ])('renders children when data is %s', (_label, data) => {
-    mockUseMultiQuery.mockReturnValue({
-      data,
-      isLoading: false,
-      isError: false,
-      errors: [null],
-    })
-
-    render(
-      <AntdResult data={{ id: 'edge', reqIndex: 0 }}>
-        <div data-testid="page-content">Should render</div>
-      </AntdResult>,
-    )
-
-    expect(screen.getByTestId('page-content')).toBeInTheDocument()
-  })
-})
+// Edge cases for isEmptyAtPath are covered in utils.test.ts

--- a/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.test.tsx
+++ b/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.test.tsx
@@ -1,0 +1,312 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { AntdResult } from './AntdResult'
+import { useMultiQuery } from '../../../DynamicRendererWithProviders/providers/hybridDataProvider'
+import { usePartsOfUrl } from '../../../DynamicRendererWithProviders/providers/partsOfUrlContext'
+
+jest.mock('../../../DynamicRendererWithProviders/providers/hybridDataProvider', () => ({
+  useMultiQuery: jest.fn(),
+}))
+
+jest.mock('../../../DynamicRendererWithProviders/providers/partsOfUrlContext', () => ({
+  usePartsOfUrl: jest.fn(),
+}))
+
+const mockUseMultiQuery = useMultiQuery as unknown as jest.Mock
+const mockUsePartsOfUrl = usePartsOfUrl as unknown as jest.Mock
+
+const defaultPartsOfUrl = { partsOfUrl: ['openapi-ui', 'default', 'practice'] }
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockUsePartsOfUrl.mockReturnValue(defaultPartsOfUrl)
+})
+
+// ── Loading state ──────────────────────────────────────────────
+
+describe('loading state', () => {
+  it('renders nothing while loading', () => {
+    mockUseMultiQuery.mockReturnValue({ data: {}, isLoading: true, isError: false, errors: [] })
+
+    const { container } = render(
+      <AntdResult data={{ id: 'test', reqIndex: 0 }}>
+        <div data-testid="child" />
+      </AntdResult>,
+    )
+
+    expect(container.innerHTML).toBe('')
+    expect(screen.queryByTestId('child')).not.toBeInTheDocument()
+  })
+})
+
+// ── Manual mode (no reqIndex) ──────────────────────────────────
+
+describe('manual mode (no reqIndex)', () => {
+  it('renders Result with static status, title, subTitle', () => {
+    mockUseMultiQuery.mockReturnValue({ data: {}, isLoading: false, isError: false, errors: [] })
+
+    render(<AntdResult data={{ id: 'manual', status: '403', title: 'Access Denied', subTitle: 'No permission' }} />)
+
+    expect(screen.getByText('Access Denied')).toBeInTheDocument()
+    expect(screen.getByText('No permission')).toBeInTheDocument()
+  })
+
+  it('renders children inside Result in manual mode', () => {
+    mockUseMultiQuery.mockReturnValue({ data: {}, isLoading: false, isError: false, errors: [] })
+
+    render(
+      <AntdResult data={{ id: 'manual-children', status: 'info', title: 'Info' }}>
+        <div data-testid="manual-child">Extra content</div>
+      </AntdResult>,
+    )
+
+    expect(screen.getByText('Info')).toBeInTheDocument()
+    expect(screen.getByTestId('manual-child')).toBeInTheDocument()
+  })
+
+  it('supports template syntax in title and subTitle', () => {
+    mockUseMultiQuery.mockReturnValue({
+      data: { req0: { metadata: { name: 'my-pod' } } },
+      isLoading: false,
+      isError: false,
+      errors: [],
+    })
+
+    render(
+      <AntdResult
+        data={{
+          id: 'templates',
+          status: 'warning',
+          title: 'Namespace: {2}',
+          subTitle: 'Cluster: {1}',
+        }}
+      />,
+    )
+
+    expect(screen.getByText('Namespace: practice')).toBeInTheDocument()
+    expect(screen.getByText('Cluster: default')).toBeInTheDocument()
+  })
+})
+
+// ── Auto-detect mode (reqIndex provided) ───────────────────────
+
+describe('auto-detect mode (reqIndex)', () => {
+  it('renders children when request succeeded and data exists', () => {
+    mockUseMultiQuery.mockReturnValue({
+      data: { req0: { items: [{ metadata: { name: 'nginx' } }] } },
+      isLoading: false,
+      isError: false,
+      errors: [null],
+    })
+
+    render(
+      <AntdResult data={{ id: 'ok', reqIndex: 0 }}>
+        <div data-testid="page-content">Pod details here</div>
+      </AntdResult>,
+    )
+
+    expect(screen.getByTestId('page-content')).toBeInTheDocument()
+  })
+
+  it('renders null when no error and no children', () => {
+    mockUseMultiQuery.mockReturnValue({
+      data: { req0: { items: [{ metadata: { name: 'nginx' } }] } },
+      isLoading: false,
+      isError: false,
+      errors: [null],
+    })
+
+    const { container } = render(<AntdResult data={{ id: 'no-children', reqIndex: 0 }} />)
+
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders error Result when HTTP error exists', () => {
+    mockUseMultiQuery.mockReturnValue({
+      data: {},
+      isLoading: false,
+      isError: true,
+      errors: [{ response: { status: 403, statusText: 'Forbidden' }, message: 'Request failed' }],
+    })
+
+    render(
+      <AntdResult data={{ id: 'http-error', reqIndex: 0 }}>
+        <div data-testid="should-not-render" />
+      </AntdResult>,
+    )
+
+    expect(screen.getByText('Access Denied')).toBeInTheDocument()
+    expect(screen.getByText('Forbidden')).toBeInTheDocument()
+    expect(screen.queryByTestId('should-not-render')).not.toBeInTheDocument()
+  })
+
+  it('uses error message when statusText is empty', () => {
+    mockUseMultiQuery.mockReturnValue({
+      data: {},
+      isLoading: false,
+      isError: true,
+      errors: [{ response: { status: 500 }, message: 'Internal Server Error' }],
+    })
+
+    render(<AntdResult data={{ id: 'error-msg', reqIndex: 0 }} />)
+
+    // Ant Design's 500 SVG also has a <title>Server Error</title>, so multiple matches
+    expect(screen.getAllByText('Server Error').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('Internal Server Error')).toBeInTheDocument()
+  })
+
+  it('allows YAML to override status and title on HTTP error', () => {
+    mockUseMultiQuery.mockReturnValue({
+      data: {},
+      isLoading: false,
+      isError: true,
+      errors: [{ response: { status: 403 }, message: 'Forbidden' }],
+    })
+
+    render(<AntdResult data={{ id: 'override', reqIndex: 0, status: 'warning', title: 'Custom Title' }} />)
+
+    expect(screen.getByText('Custom Title')).toBeInTheDocument()
+  })
+})
+
+// ── emptyAsNotFound ────────────────────────────────────────────
+
+describe('emptyAsNotFound', () => {
+  it('renders 404 Result when items is empty and flag is true', () => {
+    mockUseMultiQuery.mockReturnValue({
+      data: { req0: { items: [] } },
+      isLoading: false,
+      isError: false,
+      errors: [null],
+    })
+
+    render(
+      <AntdResult data={{ id: 'empty', reqIndex: 0, emptyAsNotFound: true }}>
+        <div data-testid="should-not-render" />
+      </AntdResult>,
+    )
+
+    expect(screen.getByText('Not Found')).toBeInTheDocument()
+    expect(screen.getByText('The requested resource was not found')).toBeInTheDocument()
+    expect(screen.queryByTestId('should-not-render')).not.toBeInTheDocument()
+  })
+
+  it('renders children when items is empty but flag is false', () => {
+    mockUseMultiQuery.mockReturnValue({
+      data: { req0: { items: [] } },
+      isLoading: false,
+      isError: false,
+      errors: [null],
+    })
+
+    render(
+      <AntdResult data={{ id: 'no-flag', reqIndex: 0, emptyAsNotFound: false }}>
+        <div data-testid="page-content">Should render</div>
+      </AntdResult>,
+    )
+
+    expect(screen.getByTestId('page-content')).toBeInTheDocument()
+  })
+
+  it('renders children when items is empty but flag is not set', () => {
+    mockUseMultiQuery.mockReturnValue({
+      data: { req0: { items: [] } },
+      isLoading: false,
+      isError: false,
+      errors: [null],
+    })
+
+    render(
+      <AntdResult data={{ id: 'no-flag-default', reqIndex: 0 }}>
+        <div data-testid="page-content">Should render</div>
+      </AntdResult>,
+    )
+
+    expect(screen.getByTestId('page-content')).toBeInTheDocument()
+  })
+
+  it('renders children when items has data and flag is true', () => {
+    mockUseMultiQuery.mockReturnValue({
+      data: { req0: { items: [{ metadata: { name: 'nginx' } }] } },
+      isLoading: false,
+      isError: false,
+      errors: [null],
+    })
+
+    render(
+      <AntdResult data={{ id: 'has-data', reqIndex: 0, emptyAsNotFound: true }}>
+        <div data-testid="page-content">Pod exists</div>
+      </AntdResult>,
+    )
+
+    expect(screen.getByTestId('page-content')).toBeInTheDocument()
+  })
+
+  it('allows YAML to override status and title on empty list', () => {
+    mockUseMultiQuery.mockReturnValue({
+      data: { req0: { items: [] } },
+      isLoading: false,
+      isError: false,
+      errors: [null],
+    })
+    mockUsePartsOfUrl.mockReturnValue({ partsOfUrl: ['nginx-missing', 'default'] })
+
+    render(
+      <AntdResult
+        data={{
+          id: 'custom-empty',
+          reqIndex: 0,
+          emptyAsNotFound: true,
+          status: 'warning',
+          title: 'Pod {0} is not found',
+          subTitle: 'Namespace: {1}',
+        }}
+      />,
+    )
+
+    expect(screen.getByText('Pod nginx-missing is not found')).toBeInTheDocument()
+    expect(screen.getByText('Namespace: default')).toBeInTheDocument()
+  })
+
+  it('prefers HTTP error over emptyAsNotFound when both apply', () => {
+    mockUseMultiQuery.mockReturnValue({
+      data: { req0: { items: [] } },
+      isLoading: false,
+      isError: true,
+      errors: [{ response: { status: 403, statusText: 'Forbidden' }, message: 'Forbidden' }],
+    })
+
+    render(<AntdResult data={{ id: 'error-priority', reqIndex: 0, emptyAsNotFound: true }} />)
+
+    expect(screen.getByText('Access Denied')).toBeInTheDocument()
+    expect(screen.getByText('Forbidden')).toBeInTheDocument()
+  })
+})
+
+// ── isEmptyK8sList edge cases ──────────────────────────────────
+
+describe('isEmptyK8sList edge cases', () => {
+  it.each([
+    ['null reqData', { req0: null }],
+    ['undefined reqData', {}],
+    ['non-object reqData', { req0: 'string-value' }],
+    ['reqData without items key', { req0: { metadata: {} } }],
+    ['items is not an array', { req0: { items: 'not-array' } }],
+    ['items is an object', { req0: { items: {} } }],
+  ])('renders children when data is %s', (_label, data) => {
+    mockUseMultiQuery.mockReturnValue({
+      data,
+      isLoading: false,
+      isError: false,
+      errors: [null],
+    })
+
+    render(
+      <AntdResult data={{ id: 'edge', reqIndex: 0, emptyAsNotFound: true }}>
+        <div data-testid="page-content">Should render</div>
+      </AntdResult>,
+    )
+
+    expect(screen.getByTestId('page-content')).toBeInTheDocument()
+  })
+})

--- a/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.tsx
+++ b/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.tsx
@@ -22,12 +22,22 @@ const getDefaultTitle = (status: string | number) => {
   return 'Error'
 }
 
-/** Check whether the K8s list response for a given reqIndex has zero items. */
-const isEmptyK8sList = (multiQueryData: Record<string, unknown>, reqIndex: number): boolean => {
+/** Resolve a dot-separated path (e.g. ".items" or ".data.results") on an object. */
+const getValueByPath = (obj: Record<string, unknown>, path: string): unknown =>
+  path
+    .replace(/^\./, '')
+    .split('.')
+    .reduce<unknown>((current, key) => {
+      if (current == null || typeof current !== 'object') return undefined
+      return (current as Record<string, unknown>)[key]
+    }, obj)
+
+/** Check whether the response for a given reqIndex has an empty array at the specified path. */
+const isEmptyAtPath = (multiQueryData: Record<string, unknown>, reqIndex: number, path: string): boolean => {
   const reqData = multiQueryData[`req${reqIndex}`]
   if (reqData == null || typeof reqData !== 'object') return false
-  const { items } = reqData as Record<string, unknown>
-  return Array.isArray(items) && items.length === 0
+  const value = getValueByPath(reqData as Record<string, unknown>, path)
+  return Array.isArray(value) && value.length === 0
 }
 
 export const AntdResult: FC<{
@@ -50,8 +60,10 @@ export const AntdResult: FC<{
   if (typeof data.reqIndex === 'number') {
     const error = errors[data.reqIndex]
 
-    // emptyAsNotFound: K8s list returned 200 but items is [] → treat as 404
-    const emptyListDetected = !error && data.emptyAsNotFound && isEmptyK8sList(multiQueryData, data.reqIndex)
+    // checkEmpty (default: true): response has empty array at itemsPath → treat as 404
+    const shouldCheckEmpty = data.checkEmpty !== false
+    const itemsPath = data.itemsPath ?? '.items'
+    const emptyListDetected = !error && shouldCheckEmpty && isEmptyAtPath(multiQueryData, data.reqIndex, itemsPath)
 
     if (!error && !emptyListDetected) {
       return children ?? null

--- a/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.tsx
+++ b/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.tsx
@@ -5,6 +5,7 @@ import { TDynamicComponentsAppTypeMap } from '../../types'
 import { useMultiQuery } from '../../../DynamicRendererWithProviders/providers/hybridDataProvider'
 import { usePartsOfUrl } from '../../../DynamicRendererWithProviders/providers/partsOfUrlContext'
 import { parseAll } from '../utils'
+import { isEmptyAtPath } from './utils'
 
 type TErrorWithResponse = { response?: { status?: number; statusText?: string }; message?: string }
 
@@ -20,24 +21,6 @@ const getDefaultTitle = (status: string | number) => {
   if (status === '404') return 'Not Found'
   if (status === '500') return 'Server Error'
   return 'Error'
-}
-
-/** Resolve a dot-separated path (e.g. ".items" or ".data.results") on an object. */
-const getValueByPath = (obj: Record<string, unknown>, path: string): unknown =>
-  path
-    .replace(/^\./, '')
-    .split('.')
-    .reduce<unknown>((current, key) => {
-      if (current == null || typeof current !== 'object') return undefined
-      return (current as Record<string, unknown>)[key]
-    }, obj)
-
-/** Check whether the response for a given reqIndex has an empty array at the specified path. */
-const isEmptyAtPath = (multiQueryData: Record<string, unknown>, reqIndex: number, path: string): boolean => {
-  const reqData = multiQueryData[`req${reqIndex}`]
-  if (reqData == null || typeof reqData !== 'object') return false
-  const value = getValueByPath(reqData as Record<string, unknown>, path)
-  return Array.isArray(value) && value.length === 0
 }
 
 export const AntdResult: FC<{

--- a/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.tsx
+++ b/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.tsx
@@ -22,6 +22,14 @@ const getDefaultTitle = (status: string | number) => {
   return 'Error'
 }
 
+/** Check whether the K8s list response for a given reqIndex has zero items. */
+const isEmptyK8sList = (multiQueryData: Record<string, unknown>, reqIndex: number): boolean => {
+  const reqData = multiQueryData[`req${reqIndex}`]
+  if (reqData == null || typeof reqData !== 'object') return false
+  const { items } = reqData as Record<string, unknown>
+  return Array.isArray(items) && items.length === 0
+}
+
 export const AntdResult: FC<{
   data: TDynamicComponentsAppTypeMap['antdResult']
   children?: any
@@ -42,24 +50,25 @@ export const AntdResult: FC<{
   if (typeof data.reqIndex === 'number') {
     const error = errors[data.reqIndex]
 
-    if (!error) {
+    // emptyAsNotFound: K8s list returned 200 but items is [] → treat as 404
+    const emptyListDetected = !error && data.emptyAsNotFound && isEmptyK8sList(multiQueryData, data.reqIndex)
+
+    if (!error && !emptyListDetected) {
       return children ?? null
     }
 
     const errorObj = error as TErrorWithResponse
-    const httpStatus = errorObj?.response?.status
+    const httpStatus = emptyListDetected ? 404 : errorObj?.response?.status
     const autoStatus = httpStatusToResultStatus(httpStatus)
-    const autoMessage = errorObj?.response?.statusText || errorObj?.message || String(error)
+    const autoMessage = emptyListDetected
+      ? 'The requested resource was not found'
+      : errorObj?.response?.statusText || errorObj?.message || String(error)
 
     const status = data.status ?? autoStatus
     const title = data.title ? parseAll({ text: data.title, replaceValues, multiQueryData }) : getDefaultTitle(status)
     const subTitle = data.subTitle ? parseAll({ text: data.subTitle, replaceValues, multiQueryData }) : autoMessage
 
-    return (
-      <Result status={status} title={title} subTitle={subTitle} style={data.style}>
-        {children}
-      </Result>
-    )
+    return <Result status={status} title={title} subTitle={subTitle} style={data.style} />
   }
 
   // Manual mode: no reqIndex → fully static/template-driven

--- a/src/components/organisms/DynamicComponents/molecules/AntdResult/utils.test.ts
+++ b/src/components/organisms/DynamicComponents/molecules/AntdResult/utils.test.ts
@@ -1,0 +1,85 @@
+import { getValueByPath, isEmptyAtPath } from './utils'
+
+// ── getValueByPath ───────────────────────────────────────────
+
+describe('getValueByPath', () => {
+  it('resolves a single-level path', () => {
+    expect(getValueByPath({ items: [1, 2] }, '.items')).toEqual([1, 2])
+  })
+
+  it('resolves a path without leading dot', () => {
+    expect(getValueByPath({ items: [1] }, 'items')).toEqual([1])
+  })
+
+  it('resolves a deeply nested path', () => {
+    const obj = { data: { results: { nested: 'value' } } }
+    expect(getValueByPath(obj, '.data.results.nested')).toBe('value')
+  })
+
+  it('returns undefined for missing intermediate key', () => {
+    expect(getValueByPath({ data: { other: 1 } }, '.data.results.nested')).toBeUndefined()
+  })
+
+  it('returns undefined when intermediate is null', () => {
+    expect(getValueByPath({ data: null } as unknown as Record<string, unknown>, '.data.items')).toBeUndefined()
+  })
+
+  it('returns undefined when intermediate is a primitive', () => {
+    expect(getValueByPath({ data: 42 } as unknown as Record<string, unknown>, '.data.items')).toBeUndefined()
+  })
+
+  it('returns undefined for empty object', () => {
+    expect(getValueByPath({}, '.items')).toBeUndefined()
+  })
+
+  it('returns the value even if it is falsy (0, false, empty string)', () => {
+    expect(getValueByPath({ count: 0 }, '.count')).toBe(0)
+    expect(getValueByPath({ flag: false }, '.flag')).toBe(false)
+    expect(getValueByPath({ name: '' }, '.name')).toBe('')
+  })
+})
+
+// ── isEmptyAtPath ────────────────────────────────────────────
+
+describe('isEmptyAtPath', () => {
+  it('returns true when array at path is empty', () => {
+    expect(isEmptyAtPath({ req0: { items: [] } }, 0, '.items')).toBe(true)
+  })
+
+  it('returns false when array at path has elements', () => {
+    expect(isEmptyAtPath({ req0: { items: [{ name: 'a' }] } }, 0, '.items')).toBe(false)
+  })
+
+  it('returns false when value at path is not an array', () => {
+    expect(isEmptyAtPath({ req0: { items: 'string' } }, 0, '.items')).toBe(false)
+    expect(isEmptyAtPath({ req0: { items: {} } }, 0, '.items')).toBe(false)
+    expect(isEmptyAtPath({ req0: { items: 42 } }, 0, '.items')).toBe(false)
+  })
+
+  it('returns false when reqData is null', () => {
+    expect(isEmptyAtPath({ req0: null } as unknown as Record<string, unknown>, 0, '.items')).toBe(false)
+  })
+
+  it('returns false when reqData is undefined (missing key)', () => {
+    expect(isEmptyAtPath({}, 0, '.items')).toBe(false)
+  })
+
+  it('returns false when reqData is a non-object primitive', () => {
+    expect(isEmptyAtPath({ req0: 'string' }, 0, '.items')).toBe(false)
+  })
+
+  it('returns false when path does not exist in reqData', () => {
+    expect(isEmptyAtPath({ req0: { metadata: {} } }, 0, '.items')).toBe(false)
+  })
+
+  it('works with custom paths', () => {
+    expect(isEmptyAtPath({ req1: { data: { results: [] } } }, 1, '.data.results')).toBe(true)
+    expect(isEmptyAtPath({ req1: { data: { results: [1] } } }, 1, '.data.results')).toBe(false)
+  })
+
+  it('uses the correct reqIndex', () => {
+    const data = { req0: { items: [1] }, req1: { items: [] } }
+    expect(isEmptyAtPath(data, 0, '.items')).toBe(false)
+    expect(isEmptyAtPath(data, 1, '.items')).toBe(true)
+  })
+})

--- a/src/components/organisms/DynamicComponents/molecules/AntdResult/utils.ts
+++ b/src/components/organisms/DynamicComponents/molecules/AntdResult/utils.ts
@@ -1,0 +1,17 @@
+/** Resolve a dot-separated path (e.g. ".items" or ".data.results") on an object. */
+export const getValueByPath = (obj: Record<string, unknown>, path: string): unknown =>
+  path
+    .replace(/^\./, '')
+    .split('.')
+    .reduce<unknown>((current, key) => {
+      if (current == null || typeof current !== 'object') return undefined
+      return (current as Record<string, unknown>)[key]
+    }, obj)
+
+/** Check whether the response for a given reqIndex has an empty array at the specified path. */
+export const isEmptyAtPath = (multiQueryData: Record<string, unknown>, reqIndex: number, path: string): boolean => {
+  const reqData = multiQueryData[`req${reqIndex}`]
+  if (reqData == null || typeof reqData !== 'object') return false
+  const value = getValueByPath(reqData as Record<string, unknown>, path)
+  return Array.isArray(value) && value.length === 0
+}

--- a/src/components/organisms/DynamicComponents/types/antdComponents.ts
+++ b/src/components/organisms/DynamicComponents/types/antdComponents.ts
@@ -44,6 +44,10 @@ export type TAntdIconsProps = {
 export type TAntdResultProps = {
   id: number | string
   reqIndex?: number
+  /** Treat an empty K8s list (items: []) as "404 Not Found". Useful for detail
+   *  pages that fetch a single resource via fieldSelector — the K8s API returns
+   *  200 with an empty items array instead of 404 when the resource is missing. */
+  emptyAsNotFound?: boolean
   status?: 'success' | 'error' | 'info' | 'warning' | '403' | '404' | '500' | 403 | 404 | 500
   title?: string
   subTitle?: string

--- a/src/components/organisms/DynamicComponents/types/antdComponents.ts
+++ b/src/components/organisms/DynamicComponents/types/antdComponents.ts
@@ -44,10 +44,14 @@ export type TAntdIconsProps = {
 export type TAntdResultProps = {
   id: number | string
   reqIndex?: number
-  /** Treat an empty K8s list (items: []) as "404 Not Found". Useful for detail
-   *  pages that fetch a single resource via fieldSelector — the K8s API returns
-   *  200 with an empty items array instead of 404 when the resource is missing. */
-  emptyAsNotFound?: boolean
+  /** Dot-separated path to the array in the response to check for emptiness.
+   *  Default: ".items" (K8s list response format). Can be changed for non-K8s
+   *  APIs, e.g. ".data.results" */
+  itemsPath?: string
+  /** Whether to check if the array at `itemsPath` is empty and show 404 when
+   *  it is. Default: true — antdResult reacts to empty responses by default.
+   *  Set to false to explicitly disable this check. */
+  checkEmpty?: boolean
   status?: 'success' | 'error' | 'info' | 'warning' | '403' | '404' | '500' | 403 | 404 | 500
   title?: string
   subTitle?: string


### PR DESCRIPTION
Add `emptyAsNotFound` flag to `antdResult` factory molecule. When enabled, the component detects empty K8s list responses (`items: []`) as "404 Not Found" — fixing detail pages where the K8s API returns 200 OK with an empty list instead of 404 when a resource doesn't exist (list+`fieldSelector` pattern).