### PR TITLE
[CLOUD-485]: fix AntdResult illustrations showing

### DIFF
--- a/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.test.tsx
+++ b/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.test.tsx
@@ -126,7 +126,7 @@ describe('auto-detect mode (reqIndex)', () => {
       data: {},
       isLoading: false,
       isError: true,
-      errors: [{ response: { status: 403, statusText: 'Forbidden' }, message: 'Request failed' }],
+      errors: [Object.assign(new Error('Request failed'), { response: { status: 403, statusText: 'Forbidden' } })],
     })
 
     render(
@@ -145,7 +145,7 @@ describe('auto-detect mode (reqIndex)', () => {
       data: {},
       isLoading: false,
       isError: true,
-      errors: [{ response: { status: 500 }, message: 'Internal Server Error' }],
+      errors: [Object.assign(new Error('Internal Server Error'), { response: { status: 500 } })],
     })
 
     render(<AntdResult data={{ id: 'error-msg', reqIndex: 0 }} />)
@@ -273,7 +273,7 @@ describe('checkEmpty (default: true)', () => {
       data: { req0: { items: [] } },
       isLoading: false,
       isError: true,
-      errors: [{ response: { status: 403, statusText: 'Forbidden' }, message: 'Forbidden' }],
+      errors: [Object.assign(new Error('Forbidden'), { response: { status: 403, statusText: 'Forbidden' } })],
     })
 
     render(<AntdResult data={{ id: 'error-priority', reqIndex: 0 }} />)

--- a/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.test.tsx
+++ b/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.test.tsx
@@ -357,4 +357,65 @@ describe('custom itemsPath', () => {
   })
 })
 
-// Edge cases for isEmptyAtPath are covered in utils.test.ts
+// ── WebSocket / string errors ────────────────────────────────
+
+describe('string errors (WebSocket path)', () => {
+  it('renders 404 illustration for string error with (404) suffix', () => {
+    mockUseMultiQuery.mockReturnValue({
+      data: {},
+      isLoading: false,
+      isError: true,
+      errors: ['Initial list failed (404)'],
+    })
+
+    render(<AntdResult data={{ id: 'ws-404', reqIndex: 0 }} />)
+
+    expect(screen.getByText('Not Found')).toBeInTheDocument()
+    expect(screen.getByText('Initial list failed (404)')).toBeInTheDocument()
+  })
+
+  it('renders 403 illustration for string error with (403) suffix', () => {
+    mockUseMultiQuery.mockReturnValue({
+      data: {},
+      isLoading: false,
+      isError: true,
+      errors: ['Access denied (403)'],
+    })
+
+    render(<AntdResult data={{ id: 'ws-403', reqIndex: 0 }} />)
+
+    expect(screen.getByText('Access Denied')).toBeInTheDocument()
+    expect(screen.getByText('Access denied (403)')).toBeInTheDocument()
+  })
+
+  it('renders 500 illustration for string error with (500) suffix', () => {
+    mockUseMultiQuery.mockReturnValue({
+      data: {},
+      isLoading: false,
+      isError: true,
+      errors: ['Server error (500)'],
+    })
+
+    render(<AntdResult data={{ id: 'ws-500', reqIndex: 0 }} />)
+
+    expect(screen.getAllByText('Server Error').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('Server error (500)')).toBeInTheDocument()
+  })
+
+  it('renders generic error for string without status code', () => {
+    mockUseMultiQuery.mockReturnValue({
+      data: {},
+      isLoading: false,
+      isError: true,
+      errors: ['WebSocket connection closed'],
+    })
+
+    render(<AntdResult data={{ id: 'ws-generic', reqIndex: 0 }} />)
+
+    expect(screen.getByText('Error')).toBeInTheDocument()
+    expect(screen.getByText('WebSocket connection closed')).toBeInTheDocument()
+  })
+})
+
+// Edge cases for extractHttpStatus, extractErrorMessage, isEmptyAtPath
+// are covered in utils.test.ts

--- a/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.tsx
+++ b/src/components/organisms/DynamicComponents/molecules/AntdResult/AntdResult.tsx
@@ -5,9 +5,7 @@ import { TDynamicComponentsAppTypeMap } from '../../types'
 import { useMultiQuery } from '../../../DynamicRendererWithProviders/providers/hybridDataProvider'
 import { usePartsOfUrl } from '../../../DynamicRendererWithProviders/providers/partsOfUrlContext'
 import { parseAll } from '../utils'
-import { isEmptyAtPath } from './utils'
-
-type TErrorWithResponse = { response?: { status?: number; statusText?: string }; message?: string }
+import { isEmptyAtPath, extractHttpStatus, extractErrorMessage } from './utils'
 
 const httpStatusToResultStatus = (statusCode: number | undefined) => {
   if (statusCode === 403) return '403' as const
@@ -52,12 +50,9 @@ export const AntdResult: FC<{
       return children ?? null
     }
 
-    const errorObj = error as TErrorWithResponse
-    const httpStatus = emptyListDetected ? 404 : errorObj?.response?.status
+    const httpStatus = emptyListDetected ? 404 : extractHttpStatus(error)
     const autoStatus = httpStatusToResultStatus(httpStatus)
-    const autoMessage = emptyListDetected
-      ? 'The requested resource was not found'
-      : errorObj?.response?.statusText || errorObj?.message || String(error)
+    const autoMessage = emptyListDetected ? 'The requested resource was not found' : extractErrorMessage(error)
 
     const status = data.status ?? autoStatus
     const title = data.title ? parseAll({ text: data.title, replaceValues, multiQueryData }) : getDefaultTitle(status)

--- a/src/components/organisms/DynamicComponents/molecules/AntdResult/utils.test.ts
+++ b/src/components/organisms/DynamicComponents/molecules/AntdResult/utils.test.ts
@@ -1,4 +1,4 @@
-import { getValueByPath, isEmptyAtPath } from './utils'
+import { getValueByPath, isEmptyAtPath, extractHttpStatus, extractErrorMessage } from './utils'
 
 // ── getValueByPath ───────────────────────────────────────────
 
@@ -81,5 +81,87 @@ describe('isEmptyAtPath', () => {
     const data = { req0: { items: [1] }, req1: { items: [] } }
     expect(isEmptyAtPath(data, 0, '.items')).toBe(false)
     expect(isEmptyAtPath(data, 1, '.items')).toBe(true)
+  })
+})
+
+// ── extractHttpStatus ─────────────────────────────────────────
+
+describe('extractHttpStatus', () => {
+  it('extracts status from AxiosError shape (.response.status)', () => {
+    expect(extractHttpStatus({ response: { status: 403 } })).toBe(403)
+    expect(extractHttpStatus({ response: { status: 404 } })).toBe(404)
+    expect(extractHttpStatus({ response: { status: 500 } })).toBe(500)
+  })
+
+  it('extracts status from Error with "(NNN)" in message', () => {
+    expect(extractHttpStatus({ message: 'Access denied (403)' })).toBe(403)
+    expect(extractHttpStatus({ message: 'Initial list failed (404)' })).toBe(404)
+    expect(extractHttpStatus(new Error('Server error (500)'))).toBe(500)
+  })
+
+  it('extracts status from plain string with "(NNN)" suffix', () => {
+    expect(extractHttpStatus('Initial list failed (404)')).toBe(404)
+    expect(extractHttpStatus('Access denied (403)')).toBe(403)
+    expect(extractHttpStatus('Internal server error (500)')).toBe(500)
+  })
+
+  it('returns undefined for string without status code', () => {
+    expect(extractHttpStatus('Something went wrong')).toBeUndefined()
+    expect(extractHttpStatus('WebSocket closed')).toBeUndefined()
+  })
+
+  it('does not match mid-message parentheses (no false positive)', () => {
+    expect(extractHttpStatus('Pod (nginx) crashed')).toBeUndefined()
+    expect(extractHttpStatus('Deployment (v2) rollback')).toBeUndefined()
+  })
+
+  it('returns undefined for null, undefined, and numbers', () => {
+    expect(extractHttpStatus(null)).toBeUndefined()
+    expect(extractHttpStatus(undefined)).toBeUndefined()
+    expect(extractHttpStatus(42)).toBeUndefined()
+  })
+
+  it('returns undefined for status codes outside 100-599', () => {
+    expect(extractHttpStatus('error (000)')).toBeUndefined()
+    expect(extractHttpStatus('error (600)')).toBeUndefined()
+    expect(extractHttpStatus('error (999)')).toBeUndefined()
+  })
+
+  it('prefers .response.status over message parsing', () => {
+    expect(extractHttpStatus({ response: { status: 403 }, message: 'error (500)' })).toBe(403)
+  })
+
+  it('handles trailing whitespace after "(NNN)"', () => {
+    expect(extractHttpStatus('Access denied (403) ')).toBe(403)
+  })
+})
+
+// ── extractErrorMessage ───────────────────────────────────────
+
+describe('extractErrorMessage', () => {
+  it('returns a plain string as-is', () => {
+    expect(extractErrorMessage('Initial list failed (404)')).toBe('Initial list failed (404)')
+  })
+
+  it('returns statusText from AxiosError', () => {
+    expect(extractErrorMessage({ response: { statusText: 'Forbidden' }, message: 'Request failed' })).toBe('Forbidden')
+  })
+
+  it('falls back to message when no statusText', () => {
+    expect(extractErrorMessage({ response: {}, message: 'Network error' })).toBe('Network error')
+    expect(extractErrorMessage({ message: 'Something broke' })).toBe('Something broke')
+  })
+
+  it('falls back to String(error) when no message or statusText', () => {
+    expect(extractErrorMessage({ code: 500 })).toBe('[object Object]')
+  })
+
+  it('handles Error instances', () => {
+    expect(extractErrorMessage(new Error('test error'))).toBe('test error')
+  })
+
+  it('handles null/undefined', () => {
+    expect(extractErrorMessage(null)).toBe('null')
+    expect(extractErrorMessage(undefined)).toBe('undefined')
   })
 })

--- a/src/components/organisms/DynamicComponents/molecules/AntdResult/utils.test.ts
+++ b/src/components/organisms/DynamicComponents/molecules/AntdResult/utils.test.ts
@@ -88,14 +88,15 @@ describe('isEmptyAtPath', () => {
 
 describe('extractHttpStatus', () => {
   it('extracts status from AxiosError shape (.response.status)', () => {
-    expect(extractHttpStatus({ response: { status: 403 } })).toBe(403)
-    expect(extractHttpStatus({ response: { status: 404 } })).toBe(404)
-    expect(extractHttpStatus({ response: { status: 500 } })).toBe(500)
+    const make = (status: number) => Object.assign(new Error('Request failed'), { response: { status } })
+    expect(extractHttpStatus(make(403))).toBe(403)
+    expect(extractHttpStatus(make(404))).toBe(404)
+    expect(extractHttpStatus(make(500))).toBe(500)
   })
 
   it('extracts status from Error with "(NNN)" in message', () => {
-    expect(extractHttpStatus({ message: 'Access denied (403)' })).toBe(403)
-    expect(extractHttpStatus({ message: 'Initial list failed (404)' })).toBe(404)
+    expect(extractHttpStatus(new Error('Access denied (403)'))).toBe(403)
+    expect(extractHttpStatus(new Error('Initial list failed (404)'))).toBe(404)
     expect(extractHttpStatus(new Error('Server error (500)'))).toBe(500)
   })
 
@@ -128,11 +129,17 @@ describe('extractHttpStatus', () => {
   })
 
   it('prefers .response.status over message parsing', () => {
-    expect(extractHttpStatus({ response: { status: 403 }, message: 'error (500)' })).toBe(403)
+    const err = Object.assign(new Error('error (500)'), { response: { status: 403 } })
+    expect(extractHttpStatus(err)).toBe(403)
   })
 
   it('handles trailing whitespace after "(NNN)"', () => {
     expect(extractHttpStatus('Access denied (403) ')).toBe(403)
+  })
+
+  it('returns undefined for plain objects (not Error instances)', () => {
+    expect(extractHttpStatus({ response: { status: 403 } })).toBeUndefined()
+    expect(extractHttpStatus({ message: 'error (404)' })).toBeUndefined()
   })
 })
 
@@ -144,15 +151,18 @@ describe('extractErrorMessage', () => {
   })
 
   it('returns statusText from AxiosError', () => {
-    expect(extractErrorMessage({ response: { statusText: 'Forbidden' }, message: 'Request failed' })).toBe('Forbidden')
+    const err = Object.assign(new Error('Request failed'), { response: { statusText: 'Forbidden' } })
+    expect(extractErrorMessage(err)).toBe('Forbidden')
   })
 
   it('falls back to message when no statusText', () => {
-    expect(extractErrorMessage({ response: {}, message: 'Network error' })).toBe('Network error')
-    expect(extractErrorMessage({ message: 'Something broke' })).toBe('Something broke')
+    const errEmptyResp = Object.assign(new Error('Network error'), { response: {} })
+    expect(extractErrorMessage(errEmptyResp)).toBe('Network error')
+    expect(extractErrorMessage(new Error('Something broke'))).toBe('Something broke')
   })
 
-  it('falls back to String(error) when no message or statusText', () => {
+  it('falls back to String(error) for non-Error values', () => {
+    expect(extractErrorMessage(42)).toBe('42')
     expect(extractErrorMessage({ code: 500 })).toBe('[object Object]')
   })
 

--- a/src/components/organisms/DynamicComponents/molecules/AntdResult/utils.ts
+++ b/src/components/organisms/DynamicComponents/molecules/AntdResult/utils.ts
@@ -12,27 +12,22 @@ const extractStatusFromString = (msg: string): number | undefined => {
  * - Error / string with "(NNN)" suffix: regex parse
  */
 export const extractHttpStatus = (error: unknown): number | undefined => {
-  if (error != null && typeof error === 'object') {
-    const resp = (error as Record<string, unknown>).response
-    if (resp != null && typeof resp === 'object') {
-      const { status } = resp as Record<string, unknown>
-      if (typeof status === 'number') return status
-    }
-    const { message } = error as Record<string, unknown>
-    if (typeof message === 'string') return extractStatusFromString(message)
-  }
   if (typeof error === 'string') return extractStatusFromString(error)
+  if (error instanceof Error) {
+    const { response } = error as { response?: { status?: unknown } }
+    if (typeof response?.status === 'number') return response.status
+    return extractStatusFromString(error.message)
+  }
   return undefined
 }
 
 /** Extract a human-readable message from any error shape. */
 export const extractErrorMessage = (error: unknown): string => {
   if (typeof error === 'string') return error
-  if (error != null && typeof error === 'object') {
-    const e = error as Record<string, unknown>
-    const resp = e.response as Record<string, unknown> | undefined
-    if (resp && typeof resp.statusText === 'string' && resp.statusText) return resp.statusText
-    if (typeof e.message === 'string') return e.message
+  if (error instanceof Error) {
+    const { response } = error as { response?: { statusText?: string } }
+    if (response?.statusText) return response.statusText
+    return error.message
   }
   return String(error)
 }

--- a/src/components/organisms/DynamicComponents/molecules/AntdResult/utils.ts
+++ b/src/components/organisms/DynamicComponents/molecules/AntdResult/utils.ts
@@ -1,3 +1,42 @@
+/** Extract a 3-digit HTTP status code from a trailing "(NNN)" in a string. */
+const extractStatusFromString = (msg: string): number | undefined => {
+  const match = msg.match(/\((\d{3})\)\s*$/)
+  if (!match) return undefined
+  const code = Number(match[1])
+  return code >= 100 && code <= 599 ? code : undefined
+}
+
+/**
+ * Extract an HTTP status code from any error shape:
+ * - AxiosError: `.response.status`
+ * - Error / string with "(NNN)" suffix: regex parse
+ */
+export const extractHttpStatus = (error: unknown): number | undefined => {
+  if (error != null && typeof error === 'object') {
+    const resp = (error as Record<string, unknown>).response
+    if (resp != null && typeof resp === 'object') {
+      const { status } = resp as Record<string, unknown>
+      if (typeof status === 'number') return status
+    }
+    const { message } = error as Record<string, unknown>
+    if (typeof message === 'string') return extractStatusFromString(message)
+  }
+  if (typeof error === 'string') return extractStatusFromString(error)
+  return undefined
+}
+
+/** Extract a human-readable message from any error shape. */
+export const extractErrorMessage = (error: unknown): string => {
+  if (typeof error === 'string') return error
+  if (error != null && typeof error === 'object') {
+    const e = error as Record<string, unknown>
+    const resp = e.response as Record<string, unknown> | undefined
+    if (resp && typeof resp.statusText === 'string' && resp.statusText) return resp.statusText
+    if (typeof e.message === 'string') return e.message
+  }
+  return String(error)
+}
+
 /** Resolve a dot-separated path (e.g. ".items" or ".data.results") on an object. */
 export const getValueByPath = (obj: Record<string, unknown>, path: string): unknown =>
   path


### PR DESCRIPTION
Fix `AntdResult` showing a generic red error circle instead of Ant Design's specific illustrations (403/404/500) when errors come through the WebSocket (list+watch) path. WebSocket errors are stored as plain strings like `"Access denied (403)"` in the errors array, but `AntdResult` only checked `error.response.status` (`AxiosError` shape). Added `extractHttpStatus` and `extractErrorMessage` utils that handle all three error shapes: `AxiosError` objects, `Error` instances, and plain strings with `(NNN)` suffix.

