### PR TITLE
fix(EnrichedTable): prevent JSONPath crash on unresolved flatMap placeholders

### DIFF
--- a/src/components/molecules/EnrichedTable/organisms/EnrichedTableProvider/utils.ts
+++ b/src/components/molecules/EnrichedTable/organisms/EnrichedTableProvider/utils.ts
@@ -241,8 +241,13 @@ export const prepare = ({
                 return `['${escaped}']`
               })
             }
-            const jpQueryResult = jp.query(el, `$${resolvedJsonPath}`)
-            fieldValue = Array.isArray(jpQueryResult) && jpQueryResult.length === 1 ? jpQueryResult[0] : jpQueryResult
+            if (/_flatMap[^\]]+_Key/.test(resolvedJsonPath)) {
+              // Placeholder was not resolved (row not yet expanded or key missing) — skip query
+              fieldValue = null
+            } else {
+              const jpQueryResult = jp.query(el, `$${resolvedJsonPath}`)
+              fieldValue = Array.isArray(jpQueryResult) && jpQueryResult.length === 1 ? jpQueryResult[0] : jpQueryResult
+            }
           }
 
           newFieldsForComplexJsonPath[dataIndex] = fieldValue


### PR DESCRIPTION
## Problem

When a customField `jsonPath` contains a `_flatMap*_Key` placeholder that cannot be resolved (e.g. key missing from the expanded row data), the fallback regex replacement in `prepare()` returns the placeholder unchanged. The subsequent `jp.query()` call then receives an invalid JSONPath expression and throws a parse error:

```text
Parse error on line 1: $.status.used[_flatMapData_Key]
Expecting 'STAR', 'SCRIPT_EXPRESSION', 'INTEGER', ... got 'IDENTIFIER'
```

This happens for example with `ResourceQuota` columns:
```yaml
- jsonPath: .spec.hard
  name: Data
  type: flatMap
- jsonPath: .status.used[_flatMapData_Key]
  name: Used
  type: string
```

## Fix

Check for unresolved `_flatMap*_Key` placeholders after regex substitution and return `null` instead of calling `jp.query()` with an invalid expression.